### PR TITLE
fix: change go version from 1.15 to 1.20 to avoid compilation error

### DIFF
--- a/deployment/install/install.sh
+++ b/deployment/install/install.sh
@@ -24,7 +24,7 @@ END
 
 rabia_folder=~/go/src/rabia        # the path to the Rabia folder
 redis_folder=~                     # the path where Redis is installed
-go_tar=go1.15.8.linux-amd64.tar.gz # the version of Golang to be downloaded in install_go
+go_tar=go1.20.2.linux-amd64.tar.gz # the version of Golang to be downloaded in install_go
 py_ver=python3.8                   # the version of Python to be downloaded in install_python
 redis_ver=redis-6.2.2
 


### PR DESCRIPTION
I changed the go version specified in the install.sh file of Rabia to fix a compilation error during the initial installation.
As it's described in the issue haochenpan/rabia#32 this error is caused by the dependency _syscall_ which in turn requires the _sys_ package with Go version 1.17 or higher.

To avoid the compilation error I changed the go version defined in install.sh from 1.15.8 to the current latest version 1.20.2.

Please review this pull request and if it looks good, approve it


